### PR TITLE
update: change response code in response utility

### DIFF
--- a/utils/response.go
+++ b/utils/response.go
@@ -42,7 +42,7 @@ func ResponseUnauthenticated(c *fiber.Ctx, data interface{}, message string) err
 // ResponseValidationError : returning json structur for validation error request
 func ResponseValidationError(c *fiber.Ctx, data interface{}, message string) error {
 	return c.JSON(fiber.Map{
-		"status":  304,
+		"status": 400,
 		"message": message,
 		"data":    data,
 	})


### PR DESCRIPTION
Hi bro! let me update your response code for this util

Because 304 is not modified while 400 is bad request.

From Richardson and Ruby's RESTful Web Services

```
400 (“Bad Request”)
Importance: High.
This is the generic client-side error status, used when no other 4xx error code is appropriate. It’s commonly used when the client submits a representation along with a PUT or POST request, and the representation is in the right format, but it doesn’t make any sense. (p. 381)
```

If "validation failure" means that there is some client error in the request, then use HTTP 400 (Bad Request).

Hope it helps!